### PR TITLE
Add hover functionality with CSS transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Filters Plugin for Tailwind CSS
 
-## Requirements
-
-This plugin requires Tailwind CSS 1.2 or later. If your project uses an older version of Tailwind, you should install the latest 2.x version of this plugin (`npm install tailwindcss-filters@2.x`).
-
 ## Installation
 
 ```bash
@@ -28,7 +24,7 @@ module.exports = {
     },
   },
   variants: {
-    filter: ['responsive'], // defaults to ['responsive']
+    filter: ['responsive', 'hover'], // defaults to ['responsive', 'hover']
     backdropFilter: ['responsive'], // defaults to ['responsive']
   },
   plugins: [
@@ -49,4 +45,29 @@ This plugin generates the following utilities:
 .backdrop-[key] {
   backdrop-filter: [value];
 }
+```
+
+### Hover
+
+The following example shows how to apply the grayscale filter to a background image and a hover style that will set the filter to 'none' (showing the image in color):
+
+````
+<div class="filter-grayscale hover:filter-none" style="background-image: url(...)">...</div>
+````
+
+#### Transition
+You can specify a CSS transition and set the transition duration like so:
+
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    filter: {
+      'none(400)': 'none', //400ms transition duration
+      'grayscale(600)': 'grayscale(1)' //600ms transition duration
+    },
+    ...
+  },
+  ...
+};
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Filters Plugin for Tailwind CSS
 
+## Requirements
+
+This plugin requires Tailwind CSS 1.2 or later. If your project uses an older version of Tailwind, you should install the latest 2.x version of this plugin (`npm install tailwindcss-filters@2.x`).
+
 ## Installation
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -4,25 +4,37 @@ const _ = require('lodash');
 module.exports = plugin(function({ theme, variants, e, addUtilities }) {
   const filterUtilities = _.fromPairs(
     _.map(theme('filter'), (value, modifier) => {
-      return [
-        `.${e(`filter-${modifier}`)}`,
-        {
-          filter: value,
-        },
-      ];
+      return getPairs({
+        modifier: modifier,
+        filter: value,
+        prefix: 'filter'
+      });
     })
   );
 
   const backdropFilterUtilities = _.fromPairs(
     _.map(theme('backdropFilter'), (value, modifier) => {
-      return [
-        `.${e(`backdrop-${modifier}`)}`,
-        {
-          backdropFilter: value,
-        },
-      ];
+      let args = {
+        modifier: modifier,
+        backdropFilter: value,
+        prefix: 'backdrop'
+      }
+      return getPairs(args);
     })
   );
+  
+  function getPairs(args){
+    const {prefix, modifier, ...value} = args;
+      if(args.prefix === 'filter' && args.modifier.indexOf('(') !== -1){
+        let duration = args.modifier.replace( /(^.*\(|\).*$)/g, '' );
+        args.modifier = args.modifier.substring(0, args.modifier.indexOf('(')).trim();
+        value['transition'] = `filter ${duration}ms linear`;
+      } 
+      return [
+        `.${e(`${args.prefix}-${args.modifier}`)}`,
+        value
+      ]
+  }
 
   addUtilities(filterUtilities, variants('filter'));
   addUtilities(backdropFilterUtilities, variants('backdropFilter'));
@@ -32,7 +44,7 @@ module.exports = plugin(function({ theme, variants, e, addUtilities }) {
     backdropFilter: {},
   },
   variants: {
-    filter: ['responsive'],
+    filter: ['responsive', 'hover'],
     backdropFilter: ['responsive'],
   },
 });


### PR DESCRIPTION
Hi there,
I've written a bit of code that allows the ability to remove a filter when hovered over (or the other way around). It also comes with optional CSS transitions for which you can configure the duration.

A simple test for you would be:

````
//tailwind.config.js
...
filter: { 
    'none(400)': 'none', //400ms transition duration
    'grayscale(600)': 'grayscale(1)' //600ms transition duration
    },
...
````
And in your HTML:
````
<div class="filter-grayscale hover:filter-none h-screen bg-cover bg-center" style="background-image: url(https://images.unsplash.com/photo-1500964757637-c85e8a162699?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1978&q=80)"></div>
````

This would style the image with the grayscale filter, and then on hover is would transition to no filter (taking 400ms), and then on mouse out it would transition back to color (taking 600ms).

I hope you like it :)

Richard
